### PR TITLE
Remove CSS duplications by using classnames library and implement the inactive story styles

### DIFF
--- a/src/Stories/Stories.js
+++ b/src/Stories/Stories.js
@@ -30,7 +30,7 @@ export function Stories() {
           className="all-circles"
         >
           {storiesData.map((user, index) => (
-            <StoryAvatar user={user} index={index} />
+            <StoryAvatar user={user} index={index} isUserNameNeeded={true} />
           ))}
         </div>
         

--- a/src/StoryAvatar/StoryAvatar.js
+++ b/src/StoryAvatar/StoryAvatar.js
@@ -1,19 +1,31 @@
-import "./StoryAvatar.css";
-import React from "react";
-import { Link } from "react-router-dom";
+import './StoryAvatar.css';
+import React from 'react';
+import { Link } from 'react-router-dom';
+import cx from 'classnames';
 
 export function StoryAvatar({ user, isUserNameNeeded }) {
   const userId = user.user_id;
 
   return (
-    <div id={isUserNameNeeded? "" : "user-avatar-small"} className="story-avatar">
+    <div
+      className={cx('story-avatar', {
+        'is-small': !isUserNameNeeded,
+      })}
+    >
       <div className="circle">
         <Link className="circle2" to={`/stories/${userId}`}>
-          <img  src={user.user_thumbnail} alt={`${user.user_name} avatar`} className="story-user-avatar" />
+          <img
+            src={user.user_thumbnail}
+            alt={`${user.user_name} avatar`}
+            className="story-user-avatar"
+          />
         </Link>
       </div>
-      {isUserNameNeeded ?  <p className="story-avatar-username">{user.user_name}</p> : "" }
-     
+      {isUserNameNeeded ? (
+        <p className="story-avatar-username">{user.user_name}</p>
+      ) : (
+        ''
+      )}
     </div>
   );
 }

--- a/src/StoryAvatar/StoryAvatar.js
+++ b/src/StoryAvatar/StoryAvatar.js
@@ -8,9 +8,7 @@ export function StoryAvatar({ user, isUserNameNeeded }) {
 
   return (
     <div
-      className={cx('story-avatar', {
-        'is-small': !isUserNameNeeded,
-      })}
+      className="story-avatar"
     >
       <div className="circle">
         <Link className="circle2" to={`/stories/${userId}`}>

--- a/src/StoryAvatar/StoryAvatar.js
+++ b/src/StoryAvatar/StoryAvatar.js
@@ -2,17 +2,18 @@ import "./StoryAvatar.css";
 import React from "react";
 import { Link } from "react-router-dom";
 
-export function StoryAvatar({ user }) {
+export function StoryAvatar({ user, isUserNameNeeded }) {
   const userId = user.user_id;
 
   return (
-    <div className="story-avatar">
+    <div id={isUserNameNeeded? "" : "user-avatar-small"} className="story-avatar">
       <div className="circle">
         <Link className="circle2" to={`/stories/${userId}`}>
-          <img src={user.user_thumbnail} alt={`${user.user_name} avatar`} className="story-user-avatar" />
+          <img  src={user.user_thumbnail} alt={`${user.user_name} avatar`} className="story-user-avatar" />
         </Link>
       </div>
-      <p className="story-avatar-username">{user.user_name}</p>
+      {isUserNameNeeded ?  <p className="story-avatar-username">{user.user_name}</p> : "" }
+     
     </div>
   );
 }

--- a/src/UserStories/UserStories.css
+++ b/src/UserStories/UserStories.css
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css2?family=Festive&family=Zen+Kurenaido&display=swap");
+@import url('https://fonts.googleapis.com/css2?family=Festive&family=Zen+Kurenaido&display=swap');
 
 html {
   background-color: #1f1f1f;
@@ -19,9 +19,7 @@ html {
   border-radius: 8px;
   margin-left: 50px;
 }
-.stories-container.is-small {
-  
-}
+
 .instagram-logo-link {
   position: absolute;
   left: 20px;
@@ -29,7 +27,7 @@ html {
   font-size: 2em;
   color: white;
   text-decoration: none;
-  font-family: "Festive", cursive !important;
+  font-family: 'Festive', cursive !important;
   margin: 0;
 }
 
@@ -56,6 +54,15 @@ html {
   margin-bottom: -100px;
   z-index: 2;
   position: relative;
+  animation: fade-in 0.7s ease-out forwards;
+}
+@keyframes fade-in {
+  0% {
+    opacity: 0;
+  }
+  50% {
+    opacity: 0;
+  }
 }
 .story-header.is-small {
   height: 100%;
@@ -64,7 +71,7 @@ html {
   justify-content: center;
   margin-bottom: -800px;
   background: none;
-  
+  animation: none;
 }
 .progress-bars {
   grid-column: 1 / 6;
@@ -95,6 +102,9 @@ html {
   font-weight: 100;
   box-sizing: border-box;
 }
+.story-post-time.is-small {
+  margin: 0;
+}
 .story-actions {
   justify-self: flex-end;
   align-self: center;
@@ -108,9 +118,12 @@ html {
   z-index: 20;
   margin: 0 auto;
   display: grid;
-  grid-template-areas: "left right";
+  grid-template-areas: 'left right';
   width: 500px;
   opacity: 0.2;
+}
+.story-body {
+  transition: transform 0.5s ease-out;
 }
 .story-body.is-small {
   transform: scale(0.4);
@@ -165,7 +178,7 @@ html {
 }
 ::-webkit-input-placeholder {
   color: white;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica,
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica,
     Arial, sans-serif;
   max-width: 110px;
 }

--- a/src/UserStories/UserStories.css
+++ b/src/UserStories/UserStories.css
@@ -9,7 +9,7 @@ html {
 }
 .stories-scrollable {
   display: flex;
-  padding-left: 100vw;
+  padding-left: 50vw;
   transition: transform 0.5s ease-in-out;
 }
 .stories-container {

--- a/src/UserStories/UserStories.css
+++ b/src/UserStories/UserStories.css
@@ -20,9 +20,8 @@ html {
   margin-left: 50px;
 }
 .stories-container.is-small {
-  transform: scale(0.4);
+  
 }
-
 .instagram-logo-link {
   position: absolute;
   left: 20px;
@@ -58,9 +57,17 @@ html {
   z-index: 2;
   position: relative;
 }
-
+.story-header.is-small {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  margin-bottom: -800px;
+  background: none;
+  
+}
 .progress-bars {
-  grid-column: 1 / 5;
+  grid-column: 1 / 6;
   display: flex;
   gap: 2px;
   margin-top: 10px;
@@ -90,6 +97,7 @@ html {
 }
 .story-actions {
   justify-self: flex-end;
+  align-self: center;
 }
 .story-actions button {
   color: white;
@@ -105,6 +113,7 @@ html {
   opacity: 0.2;
 }
 .story-body.is-small {
+  transform: scale(0.4);
   opacity: 0.2;
 }
 .next-button,
@@ -164,31 +173,4 @@ html {
   align-self: flex-end;
   margin-bottom: 20px;
   padding: 0 5px 0 15px;
-}
-
-#user-avatar-small {
-  position: absolute;
-  top: 280%;
-  right: 45%;
-  transform: scale(2.5);
-}
-.story-username.is-small {
-  position: absolute;
-  top: 420%;
-  transform: scale(2.5);
-  right: 43%;
-  display: block;
-  line-height: 16px;
-  max-width: 75px;
-  overflow: hidden;
-  text-align: center;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.story-post-time.is-small {
-  position: absolute;
-  top: 470%;
-  right: 50%;
-  transform: scale(2);
 }

--- a/src/UserStories/UserStories.css
+++ b/src/UserStories/UserStories.css
@@ -1,9 +1,8 @@
-@import url('https://fonts.googleapis.com/css2?family=Festive&family=Zen+Kurenaido&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Festive&family=Zen+Kurenaido&display=swap");
 
 html {
   background-color: #1f1f1f;
 }
-
 .all-stories-container {
   background-color: #1f1f1f;
   overflow: hidden;
@@ -13,7 +12,6 @@ html {
   padding-left: 100vw;
   transition: transform 0.5s ease-in-out;
 }
-
 .stories-container {
   margin: 20px auto;
   height: 800px;
@@ -21,9 +19,6 @@ html {
   border-radius: 8px;
   margin-left: 50px;
 }
-.stories-container.is-extended {
-}
-
 .stories-container.is-small {
   transform: scale(0.4);
 }
@@ -35,7 +30,7 @@ html {
   font-size: 2em;
   color: white;
   text-decoration: none;
-  font-family: 'Festive', cursive !important;
+  font-family: "Festive", cursive !important;
   margin: 0;
 }
 
@@ -63,9 +58,7 @@ html {
   z-index: 2;
   position: relative;
 }
-.story-user-avatar-username {
-  display: flex;
-}
+
 .progress-bars {
   grid-column: 1 / 5;
   display: flex;
@@ -84,6 +77,17 @@ html {
   background: white;
   transition: width 200ms linear;
 }
+.story-username {
+  align-self: center;
+  padding: 0 10px;
+  box-sizing: border-box;
+}
+.story-post-time {
+  display: flex;
+  align-self: center;
+  font-weight: 100;
+  box-sizing: border-box;
+}
 .story-actions {
   justify-self: flex-end;
 }
@@ -96,8 +100,11 @@ html {
   z-index: 20;
   margin: 0 auto;
   display: grid;
-  grid-template-areas: 'left right';
+  grid-template-areas: "left right";
   width: 500px;
+  opacity: 0.2;
+}
+.story-body.is-small {
   opacity: 0.2;
 }
 .next-button,
@@ -122,7 +129,7 @@ html {
 .story-footer {
   z-index: 2;
   position: relative;
-  margin-top: -153.7px;
+  margin-top: -184px;
   display: flex;
   justify-content: center;
   height: 150px;
@@ -139,64 +146,49 @@ html {
   border-radius: 22px;
   height: 44px;
   padding-left: 30px;
-  margin-bottom: 25px;
+  margin-bottom: 10px;
   box-sizing: border-box;
   align-self: flex-end;
   background: none;
   text-overflow: ellipsis;
-
   white-space: nowrap;
   overflow: hidden;
 }
 ::-webkit-input-placeholder {
   color: white;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica,
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica,
     Arial, sans-serif;
   max-width: 110px;
 }
 .direct-story-icon {
   align-self: flex-end;
-  margin-bottom: 35px;
+  margin-bottom: 20px;
   padding: 0 5px 0 15px;
 }
 
 #user-avatar-small {
   position: absolute;
-  top: 250%;
+  top: 280%;
   right: 45%;
-  transform: scale(2);
+  transform: scale(2.5);
 }
-.username-small {
+.story-username.is-small {
   position: absolute;
-  top: 300%;
+  top: 420%;
+  transform: scale(2.5);
   right: 43%;
   display: block;
   line-height: 16px;
-  max-width: 60px;
+  max-width: 75px;
   overflow: hidden;
   text-align: center;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.secondary-story-post-time {
-  position: absolute;
-  top: 330%;
-  right: 50%;
-}
-.secondary-story-header {
-  box-sizing: border-box;
-  color: white;
-  display: grid;
-  grid-template-columns: min-content min-content min-content 1fr;
 
-  background: linear-gradient(
-    180deg,
-    rgba(38, 38, 38, 0.8) 0%,
-    rgba(38, 38, 38, 0) 100%
-  );
-  padding: 10px;
-  height: 100px;
-  margin-bottom: -100px;
-  z-index: 2;
-  position: relative;
+.story-post-time.is-small {
+  position: absolute;
+  top: 470%;
+  right: 50%;
+  transform: scale(2);
 }

--- a/src/UserStories/UserStories.js
+++ b/src/UserStories/UserStories.js
@@ -152,12 +152,6 @@ export function UserStories({ userId }) {
                 ) : (
                   <StoryAvatar
                     user={user}
-                    style={{
-                      position: 'absolute',
-                      top: '290%',
-                      right: '45%',
-                      transform: 'scale(3.5)',
-                    }}
                   />
                 )}
 

--- a/src/UserStories/UserStories.js
+++ b/src/UserStories/UserStories.js
@@ -7,19 +7,21 @@ import {
   VolumeOff,
   ChevronLeft,
   ChevronRight,
-} from '@mui/icons-material';
+  VolumeDown,
+} from "@mui/icons-material";
 
-import { IconButton } from '@mui/material';
-import React, { useRef } from 'react';
-import { useHistory } from 'react-router';
-import { Link } from 'react-router-dom';
-import { Avatar } from '../Avatar/Avatar';
-import storiesData from '../Data/IG-Stories.json';
-import { StoryImage } from '../StoryImage/StoryImage';
-import { StoryVideo } from '../StoryVideo/StoryVideo';
-import { absoluteToRelativeDate } from '../utils';
-import cx from 'classnames';
-import './UserStories.css';
+import { IconButton } from "@mui/material";
+import React, { useRef } from "react";
+import { useHistory } from "react-router";
+import { Link } from "react-router-dom";
+import { Avatar } from "../Avatar/Avatar";
+import storiesData from "../Data/IG-Stories.json";
+import { StoryImage } from "../StoryImage/StoryImage";
+import { StoryVideo } from "../StoryVideo/StoryVideo";
+import { absoluteToRelativeDate } from "../utils";
+import cx from "classnames";
+import "./UserStories.css";
+import { StoryAvatar } from "../StoryAvatar/StoryAvatar";
 
 function getX(el) {
   return el?.offsetLeft;
@@ -32,7 +34,7 @@ function progressWidth(storyIndex, progressBarIndex, progress) {
   if (progressBarIndex === storyIndex) {
     return `${progress * 100}%`;
   } else if (progressBarIndex < storyIndex) {
-    return '100%';
+    return "100%";
   } else if (progressBarIndex > storyIndex) {
     return 0;
   }
@@ -102,11 +104,11 @@ export function UserStories({ userId }) {
                   setCurrentStoryWidth(width(div));
                 }
               }}
-              className={cx('stories-container', {
-                'is-extended': activeStory,
-                'is-small': !activeStory,
+              className={cx("stories-container", {
+                "is-extended": activeStory,
+                "is-small": !activeStory,
               })}
-              style={{ transition: 'all 0.5s ease-out' }}
+              style={{ transition: "all 0.5s ease-out" }}
               key={user.user_id}
               onClick={() => {
                 if (!activeStory) {
@@ -115,8 +117,8 @@ export function UserStories({ userId }) {
                 }
               }}
             >
-              {activeStory && (
-                <div className="story-header">
+              <div className="story-header">
+                {activeStory && (
                   <div className="progress-bars">
                     {user.stories.map((story, index) => (
                       <div className="progress-bar" key={story.story_id}>
@@ -133,30 +135,69 @@ export function UserStories({ userId }) {
                       </div>
                     ))}
                   </div>
+                )}
+                {activeStory ? (
+                  <Avatar
+                    borderColor="#fff"
+                    avatar={user.user_thumbnail}
+                    style={{ display: "flex", alignSelf: "center" }}
+                    alt={user.user_name}
+                  />
+                ) : (
+                  <StoryAvatar
+                    user={user}
+                    style={{
+                      position: "absolute",
+                      top: "290%",
+                      right: "45%",
+                      transform: "scale(3.5)",
+                    }}
+                  />
+                )}
 
-                  <Avatar avatar={user.user_thumbnail} alt={user.user_name} />
-                  <p>
-                    <strong>{user.user_name}</strong>
-                  </p>
-                  <p>{absoluteToRelativeDate(story.posting_time)}</p>
+                <p
+                  className={cx("story-username", {
+                    "is-extended": activeStory,
+                    "is-small": !activeStory,
+                  })}
+                >
+                  <strong>{user.user_name}</strong>
+                </p>
+                <p
+                  className={cx("story-post-time", {
+                    "is-extended": activeStory,
+                    "is-small": !activeStory,
+                  })}
+                >
+                  {absoluteToRelativeDate(story.posting_time)}
+                </p>
+                {activeStory ? (
                   <div className="story-actions">
                     <IconButton onClick={() => setPause(!pause)}>
                       {pause ? <PlayArrow /> : <Pause />}
                     </IconButton>
                     <IconButton onClick={() => setMute(!mute)}>
-                      {mute ? <VolumeMute /> : <VolumeOff />}
+                      {mute ? <VolumeOff /> : <VolumeDown />}
                     </IconButton>
                     <IconButton>
                       <MoreHoriz />
                     </IconButton>
                   </div>
-                </div>
-              )}
-              <div className="story-body">
-                {story.story_type === 'video' ? (
+                ) : (
+                  ""
+                )}
+              </div>
+
+              <div
+                className={cx("story-body", {
+                  "is-extended": activeStory,
+                  "is-small": !activeStory,
+                })}
+              >
+                {story.story_type === "video" ? (
                   <StoryVideo
                     paused={activeStory ? pause : true}
-                    muted={activeStory ? pause : true}
+                    muted={activeStory ? mute : true}
                     videoURL={story.story_media}
                     onProgress={progressHandler}
                     key={story.story_id}
@@ -212,7 +253,8 @@ export function UserStories({ userId }) {
                   </button>
                 </div>
               )}
-              {story.can_reply ? (
+              
+              {story.can_reply && activeStory ? (
                 <div className="story-footer">
                   <input
                     type="text"
@@ -233,7 +275,7 @@ export function UserStories({ userId }) {
                   </svg>
                 </div>
               ) : (
-                ''
+                ""
               )}
             </div>
           );

--- a/src/UserStories/UserStories.js
+++ b/src/UserStories/UserStories.js
@@ -8,20 +8,20 @@ import {
   ChevronLeft,
   ChevronRight,
   VolumeDown,
-} from "@mui/icons-material";
+} from '@mui/icons-material';
 
-import { IconButton } from "@mui/material";
-import React, { useRef } from "react";
-import { useHistory } from "react-router";
-import { Link } from "react-router-dom";
-import { Avatar } from "../Avatar/Avatar";
-import storiesData from "../Data/IG-Stories.json";
-import { StoryImage } from "../StoryImage/StoryImage";
-import { StoryVideo } from "../StoryVideo/StoryVideo";
-import { absoluteToRelativeDate } from "../utils";
-import cx from "classnames";
-import "./UserStories.css";
-import { StoryAvatar } from "../StoryAvatar/StoryAvatar";
+import { IconButton } from '@mui/material';
+import React, { useRef } from 'react';
+import { useHistory } from 'react-router';
+import { Link } from 'react-router-dom';
+import { Avatar } from '../Avatar/Avatar';
+import storiesData from '../Data/IG-Stories.json';
+import { StoryImage } from '../StoryImage/StoryImage';
+import { StoryVideo } from '../StoryVideo/StoryVideo';
+import { absoluteToRelativeDate } from '../utils';
+import cx from 'classnames';
+import './UserStories.css';
+import { StoryAvatar } from '../StoryAvatar/StoryAvatar';
 
 function getX(el) {
   return el?.offsetLeft;
@@ -34,7 +34,7 @@ function progressWidth(storyIndex, progressBarIndex, progress) {
   if (progressBarIndex === storyIndex) {
     return `${progress * 100}%`;
   } else if (progressBarIndex < storyIndex) {
-    return "100%";
+    return '100%';
   } else if (progressBarIndex > storyIndex) {
     return 0;
   }
@@ -104,11 +104,11 @@ export function UserStories({ userId }) {
                   setCurrentStoryWidth(width(div));
                 }
               }}
-              className={cx("stories-container", {
-                "is-extended": activeStory,
-                "is-small": !activeStory,
+              className={cx('stories-container', {
+                'is-extended': activeStory,
+                'is-small': !activeStory,
               })}
-              style={{ transition: "all 0.5s ease-out" }}
+              style={{ transition: 'all 0.5s ease-out' }}
               key={user.user_id}
               onClick={() => {
                 if (!activeStory) {
@@ -117,7 +117,13 @@ export function UserStories({ userId }) {
                 }
               }}
             >
-              <div className="story-header">
+              <div
+                className={cx('story-header', {
+                  'is-extended': activeStory,
+                  'is-small': !activeStory,
+                })}
+                
+              >
                 {activeStory && (
                   <div className="progress-bars">
                     {user.stories.map((story, index) => (
@@ -136,41 +142,43 @@ export function UserStories({ userId }) {
                     ))}
                   </div>
                 )}
+
                 {activeStory ? (
                   <Avatar
                     borderColor="#fff"
                     avatar={user.user_thumbnail}
-                    style={{ display: "flex", alignSelf: "center" }}
+                    style={{ display: 'flex', alignSelf: 'center' }}
                     alt={user.user_name}
                   />
                 ) : (
                   <StoryAvatar
                     user={user}
                     style={{
-                      position: "absolute",
-                      top: "290%",
-                      right: "45%",
-                      transform: "scale(3.5)",
+                      position: 'absolute',
+                      top: '290%',
+                      right: '45%',
+                      transform: 'scale(3.5)',
                     }}
                   />
                 )}
 
                 <p
-                  className={cx("story-username", {
-                    "is-extended": activeStory,
-                    "is-small": !activeStory,
+                  className={cx('story-username', {
+                    'is-extended': activeStory,
+                    'is-small': !activeStory,
                   })}
                 >
                   <strong>{user.user_name}</strong>
                 </p>
                 <p
-                  className={cx("story-post-time", {
-                    "is-extended": activeStory,
-                    "is-small": !activeStory,
+                  className={cx('story-post-time', {
+                    'is-extended': activeStory,
+                    'is-small': !activeStory,
                   })}
                 >
                   {absoluteToRelativeDate(story.posting_time)}
                 </p>
+
                 {activeStory ? (
                   <div className="story-actions">
                     <IconButton onClick={() => setPause(!pause)}>
@@ -184,17 +192,17 @@ export function UserStories({ userId }) {
                     </IconButton>
                   </div>
                 ) : (
-                  ""
+                  ''
                 )}
               </div>
 
               <div
-                className={cx("story-body", {
-                  "is-extended": activeStory,
-                  "is-small": !activeStory,
+                className={cx('story-body', {
+                  'is-extended': activeStory,
+                  'is-small': !activeStory,
                 })}
               >
-                {story.story_type === "video" ? (
+                {story.story_type === 'video' ? (
                   <StoryVideo
                     paused={activeStory ? pause : true}
                     muted={activeStory ? mute : true}
@@ -253,7 +261,7 @@ export function UserStories({ userId }) {
                   </button>
                 </div>
               )}
-              
+
               {story.can_reply && activeStory ? (
                 <div className="story-footer">
                   <input
@@ -275,7 +283,7 @@ export function UserStories({ userId }) {
                   </svg>
                 </div>
               ) : (
-                ""
+                ''
               )}
             </div>
           );

--- a/src/UserStories/UserStories.js
+++ b/src/UserStories/UserStories.js
@@ -122,7 +122,6 @@ export function UserStories({ userId }) {
                   'is-extended': activeStory,
                   'is-small': !activeStory,
                 })}
-                
               >
                 {activeStory && (
                   <div className="progress-bars">


### PR DESCRIPTION
### Changes
1. This RR removes the unnecessary content from inactive stories in the story carousel. 
2. It also makes the Avatar component cover both small inative story and the main story. 
3. Expand the reusability of the Avatar component by adding `isUserNameNeeded` flag.
4. Removes duplicate CSS by using multiple class names instead of longer classnames (eg: `story-container-expanded` vs `story-container is-expanded`).

### Testing
1. Run the app by running `yarn start` or `npm start`.
2. Everything should look good (css-wise).
3. The story avatar should look good.
4. The inactive story avatar and username should look good.
