### PR TITLE
Switch to CSS grid for cleaner code

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,7 @@ import { PostPage } from "./PostPage";
 import { UserStories } from "./UserStories/UserStories";
 
 function App() {
-  const [isExtended, setIsExtended] = React.useState(false);
+  const [isExpanded, setIsExpanded] = React.useState(false);
 
   return (
     <BrowserRouter>
@@ -16,7 +16,7 @@ function App() {
           <>
             <NavBar></NavBar>
             <PostPage
-              isFloating={isExtended}
+              isFloating={isExpanded}
               postId={match.match.params.postId}
             />
           </>
@@ -26,9 +26,9 @@ function App() {
         path="/stories/:userId/"
         render={(match) => <UserStories userId={match.match.params.userId} />}
       ></Route>
-      <Route path="/" exact={!isExtended}>
+      <Route path="/" exact={!isExpanded}>
         <NavBar></NavBar>
-        <HomePage setIsExtended={setIsExtended} />
+        <HomePage setIsExpanded={setIsExpanded} />
       </Route>
     </BrowserRouter>
   );

--- a/src/HomePage.js
+++ b/src/HomePage.js
@@ -4,7 +4,7 @@ import './App.css';
 import { Stories } from './Stories/Stories';
 import { useIGData } from './hooks/useIGData';
 
-export function HomePage({ isExtended, setIsExtended }) {
+export function HomePage({ isExpanded, setIsExpanded }) {
   const {data} = useIGData();
   return (
     <div className="content-section">
@@ -13,8 +13,8 @@ export function HomePage({ isExtended, setIsExtended }) {
         <Post
           datum={datum}
           comments={datum.comments}
-          isExtended={isExtended}
-          setIsExtended={setIsExtended}
+          isExpanded={isExpanded}
+          setIsExpanded={setIsExpanded}
           index={index}
         />
       ))}

--- a/src/Post/Post.css
+++ b/src/Post/Post.css
@@ -1,37 +1,36 @@
-.content {
-  margin-top: 40px;
-  display: flex;
-  justify-content: center;
-}
-.post-container {
-  margin-bottom: 50px;
+.post-content {
   max-width: 600px;
-  border: 1px solid #ddd;
-  background-color: #fff;
+  margin: 20px auto;
+  border: 1px solid #dbdbdb;
   border-radius: 3px;
+  background: white;
+  display: grid;
+  grid-template-areas:
+    'header'
+    'img'
+    'actions'
+    'likes'
+    'caption'
+    'comments'
+    'time'
+    'input';
 }
-.comment-section {
-  display: flex;
-  flex-direction: column;
-  width: 98%;
+.post-content.is-expanded {
+  grid-template-columns: 1fr 1fr;
+  grid-template-areas:
+    'img header'
+    'img caption'
+    'img comments'
+    'img actions'
+    'img likes'
+    'img time'
+    'img input';
+  max-width: 1200px;
+  max-height: 600px;
 }
 
-.post-overlay.is-floating {
-  background-color: rgba(0, 0, 0, 0.5);
-  top: 0;
-  position: fixed;
-  display: flex;
-  width: 100%;
-  height: 100%;
-  align-items: center;
-  justify-content: center;
-}
-.post-overlay.is-extended {
-  display: flex;
-  width: 100%;
-  min-height: 90vh;
-  align-items: center;
-  justify-content: center;
+section.post-header {
+  grid-area: header;
 }
 .post-header {
   display: flex;
@@ -40,53 +39,6 @@
   border-bottom: 1px solid #dbdbdb;
   box-sizing: border-box;
   gap: 6px;
-}
-
-.post-caption-username-extended {
-  margin-right: 5px;
-  font-weight: bold;
-}
-
-.post-caption-extended {
-  padding: 0 15px;
-}
-
-.post-img-extended {
-  height: 600px;
-}
-.content-section {
-  display: flex;
-  flex-direction: column;
-}
-.post-container-floating {
-  display: flex;
-  border: 1px solid #dbdbdb;
-  background-color: white;
-  height: 600px;
-  border-radius: 0 4px 4px 0;
-}
-.comment-section-extended {
-  border-bottom: 1px solid #dbdbdb;
-  flex: 1;
-  overflow: auto;
-  padding: 0 5px;
-}
-.comment-extended {
-  display: flex;
-  padding: 5px;
-  align-items: center;
-}
-
-.caption-user-avatar-extended {
-  width: 32x;
-  height: 32px;
-  border-radius: 50%;
-  align-self: center;
-  border: 1px solid #dbdbdb;
-  margin-left: 5px;
-}
-.post-caption-avatar-text-extended {
-  display: flex;
 }
 .more-icon {
   align-self: center;
@@ -110,122 +62,89 @@
   font-size: 10px;
   color: rgb(38, 38, 38);
 }
-.post-caption-text {
-  margin: 0;
-  padding: 0;
-  margin-bottom: 5px;
-}
-.comment-caption-avatar {
-  display: flex;
-  align-self: center;
-  align-items: center;
-  gap: 5px;
-}
-.comment-user-avatar-extended {
-  width: 32px;
-  height: 32px;
-  border-radius: 50%;
-  margin-right: 15px;
-  align-self: center;
-  border: 1px solid #dbdbdb;
+
+section.img-container {
+  grid-area: img;
 }
 
-.comment-username-comment-extended {
-  flex: 1;
-}
-.post-like-replay-section-extended {
-  display: flex;
-  align-items: center;
-  color: #8e8e8e;
-}
-.reply-button {
-  background-color: white;
-  border: none;
-  padding: 0;
-  color: #8e8e8e;
-}
-.comment-time-extended {
-  padding: 0;
-  margin: 0;
-  background-color: white;
-  border: none;
-  color: #8e8e8e;
-}
-.like-button {
-  border: none;
-  background-color: white;
-  font-size: 10px;
-  padding: 0 20px;
-  color: #8e8e8e;
-}
-.post-like-button {
-  background: none;
-  border: none;
-  padding: 0;
-}
-.comment-user-info-extended {
-  flex: 1;
-  width: 100%;
-}
-.like-count-section {
-  padding: 0;
-  margin: 0;
-}
-.likes-count {
-  padding-left: 10px;
-}
-.comment-info {
-  height: 24px;
-  padding: 0;
-  margin: 0;
+section.post-actions {
+  grid-area: actions;
+  padding: 0 10px;
   display: flex;
   align-items: center;
 }
-.comment-username-comment-text {
-  flex: 1;
-  padding: 0;
+
+section.like-count {
+  grid-area: likes;
+  padding: 10px;
+}
+
+section.post-caption-section {
+  grid-area: caption;
+  padding: 5px 10px;
+  display: flex;
+  gap: 15px;
+}
+
+section.comments-section {
+  grid-area: comments;
+  overflow-y: auto;
+  max-height: 300px;
+  padding: 10px;
+}
+section.comments-section.is-expanded {
+  border-bottom: 1px solid #dbdbdb;
+}
+section.post-time-section {
+  grid-area: time;
+  padding: 0 10px;
+}
+section.comment-input-section {
+  grid-area: input;
+}
+.comment-wrapper {
+  display: flex;
+  align-items: flex-start;
+  gap: 15px;
+  margin: 3px 0;
+}
+
+.comment-wrapper.is-expanded {
+  margin: 15px 0;
+}
+.comment-text {
+  margin: 2px 0;
+}
+.post-content.post-content.is-expanded .comment-text {
   margin: 0;
 }
-.comment-username {
-  margin-right: 5px;
-  font-weight: bold;
-}
-.post-time {
-  color: #8e8e8e;
-  margin-top: 5px;
+.comment-action {
   font-size: 12px;
-}
-.post-comment-input {
-  flex: 1;
-  display: flex;
-}
-
-.post-time.is-extended {
-  margin: 0;
-  margin-left: 10px;
-}
-
-.post-img {
-  width: 600px;
-  height: 500px;
-}
-.post-caption-and-like-section {
-  padding-left: 10px;
-}
-
-.view-comments-button {
-  border: none;
+  font-weight: 400;
+  line-height: 16px;
   background: none;
-  font-size: 15px;
-  cursor: pointer;
+  border: none;
+  padding: 0;
   color: #8e8e8e;
-  text-decoration: none;
+  margin-right: 12px;
+  vertical-align: baseline;
+  margin-top: 12px;
+  display: inline-block;
 }
-.post-actions {
-  padding: 10px 0 0 10px;
+.comment-body {
+  flex: 1;
+}
+.post-overlay.is-floating {
+  background-color: rgba(0, 0, 0, 0.5);
+  top: 0;
+  position: fixed;
   display: flex;
+  width: 100%;
+  height: 100%;
   align-items: center;
+  justify-content: center;
 }
+
 .like-share-telegram-icons {
   flex: 1;
 }
@@ -256,4 +175,35 @@
   background: none;
   border: none;
   color: #0095f6;
+}
+
+.post-img {
+  width: 600px;
+  display: block;
+}
+.post-like-button {
+  background: none;
+  border: none;
+  padding: 0;
+}
+.post-comment-input {
+  flex: 1;
+  display: flex;
+}
+.post-time {
+  color: #8e8e8e;
+  margin-top: 5px;
+  font-size: 12px;
+}
+
+.view-comments-button {
+  border: none;
+  background: none;
+  font-size: 15px;
+  cursor: pointer;
+  color: #8e8e8e;
+  text-decoration: none;
+}
+.post-caption-text {
+  margin: 0;
 }

--- a/src/Post/Post.js
+++ b/src/Post/Post.js
@@ -12,7 +12,7 @@ import { useIGData } from '../hooks/useIGData';
 function PostActions({ index, is_post_liked }) {
   const { toggleLike } = useIGData();
   return (
-    <div className="post-actions">
+    <section className="post-actions">
       <div className="like-share-telegram-icons">
         <button className="post-like-button" onClick={() => toggleLike(index)}>
           <svg
@@ -68,14 +68,14 @@ function PostActions({ index, is_post_liked }) {
       >
         <path d="M43.5 48c-.4 0-.8-.2-1.1-.4L24 29 5.6 47.6c-.4.4-1.1.6-1.6.3-.6-.2-1-.8-1-1.4v-45C3 .7 3.7 0 4.5 0h39c.8 0 1.5.7 1.5 1.5v45c0 .6-.4 1.2-.9 1.4-.2.1-.4.1-.6.1zM24 26c.8 0 1.6.3 2.2.9l15.8 16V3H6v39.9l15.8-16c.6-.6 1.4-.9 2.2-.9z"></path>
       </svg>
-    </div>
+    </section>
   );
 }
 
 function PostInput({ index }) {
   const { addComment } = useIGData();
   return (
-    <div className="comment-input-section">
+    <section className="comment-input-section">
       <svg
         className="emoji"
         aria-label="Emoji"
@@ -104,21 +104,21 @@ function PostInput({ index }) {
         />
         <button className="post-button">Post</button>
       </form>
-    </div>
+    </section>
   );
 }
-function PostDate({ posting_time, isExtended }) {
+function PostDate({ posting_time }) {
   const postDate = absoluteToRelativeDate(new Date(posting_time));
   return (
-    <p className={classnames('post-time', { 'is-extended': isExtended })}>
-      {postDate?.toUpperCase()}
-    </p>
+    <section className="post-time-section">
+      <p className="post-time">{postDate?.toUpperCase()}</p>
+    </section>
   );
 }
 
-function PostHeader({ user_name, isExtended, user_thumbnail, city }) {
+function PostHeader({ user_name, user_thumbnail, city }) {
   return (
-    <div className="post-header">
+    <section className="post-header">
       <Avatar avatar={user_thumbnail} size="32" borderColor="#ddd" />
       <div className="user-info">
         <h2 className="user-name">{user_name}</h2>
@@ -126,217 +126,131 @@ function PostHeader({ user_name, isExtended, user_thumbnail, city }) {
       </div>
 
       <MoreHoriz className="more-icon" />
-    </div>
+    </section>
   );
 }
-
-export function Post({ datum, isExtended, setIsExtended, index, isFloating }) {
-  const content = (
-    <>
-      <PostHeader
-        city={datum?.city}
-        user_name={datum?.user_name}
-        user_thumbnail={datum?.user_thumbnail}
-      />
-      <div className="img-container">
-        <img
-          className="post-img"
-          src={datum?.post_image}
-          alt=""
-          loading="lazy"
-        />
-      </div>
-      <PostActions index={index} is_post_liked={datum?.is_post_liked} />
-      <div className="post-caption-and-like-section">
-        <p className="like-count-section">
-          <div className="comment-caption-avatar">
-            <Avatar
-              avatar={datum?.user_thumbnail}
-              size="24"
-              borderColor="#ddd"
-            />
-            <p className="like-count">
-              Liked by <strong>{datum?.user_name}</strong> and
-              <strong> {datum?.likes_count} others </strong>
-            </p>
-          </div>
-        </p>
-        <p className="post-caption-text">{datum?.post_caption}</p>
-        <Link
-          to={`/p/${index}`}
-          className="view-comments-button"
-          onClick={() => {
-            setIsExtended(true);
-          }}
-        >
-          View all comments
-        </Link>
-        <div className="comment-section">
-          <div className="comment-info">
-            <p className="comment-username-comment-text">
-              <span className="comment-username">
-                {datum?.comments[0].user_name}
-              </span>
-              {datum?.comments[0].comment}
-            </p>
-            <p>
-              <svg
-                aria-label="Like"
-                className="_8-yf5 "
-                color={
-                  datum?.comments[0].is_liked_by_user ? '#ed4956' : '#8e8e8e'
-                }
-                fill={
-                  datum?.comments[0].is_liked_by_user ? '#ed4956' : '#8e8e8e'
-                }
-                height="12"
-                role="img"
-                viewBox="0 0 48 48"
-                width="12"
-              >
-                <path d="M34.6 6.1c5.7 0 10.4 5.2 10.4 11.5 0 6.8-5.9 11-11.5 16S25 41.3 24 41.9c-1.1-.7-4.7-4-9.5-8.3-5.7-5-11.5-9.2-11.5-16C3 11.3 7.7 6.1 13.4 6.1c4.2 0 6.5 2 8.1 4.3 1.9 2.6 2.2 3.9 2.5 3.9.3 0 .6-1.3 2.5-3.9 1.6-2.3 3.9-4.3 8.1-4.3m0-3c-4.5 0-7.9 1.8-10.6 5.6-2.7-3.7-6.1-5.5-10.6-5.5C6 3.1 0 9.6 0 17.6c0 7.3 5.4 12 10.6 16.5.6.5 1.3 1.1 1.9 1.7l2.3 2c4.4 3.9 6.6 5.9 7.6 6.5.5.3 1.1.5 1.6.5.6 0 1.1-.2 1.6-.5 1-.6 2.8-2.2 7.8-6.8l2-1.8c.7-.6 1.3-1.2 2-1.7C42.7 29.6 48 25 48 17.6c0-8-6-14.5-13.4-14.5z"></path>
-              </svg>
-            </p>
-          </div>
-          <div className="comment-info">
-            <p className="comment-username-comment-text">
-              <span className="comment-username">
-                {datum?.comments[1].user_name}
-              </span>
-              {datum?.comments[1].comment}
-            </p>
-            <p>
-              <svg
-                aria-label="Like"
-                className="_8-yf5 "
-                color={
-                  datum?.comments[1].is_liked_by_user ? '#ed4956' : '#8e8e8e'
-                }
-                fill={
-                  datum?.comments[1].is_liked_by_user ? '#ed4956' : '#8e8e8e'
-                }
-                height="12"
-                role="img"
-                viewBox="0 0 48 48"
-                width="12"
-              >
-                <path d="M34.6 6.1c5.7 0 10.4 5.2 10.4 11.5 0 6.8-5.9 11-11.5 16S25 41.3 24 41.9c-1.1-.7-4.7-4-9.5-8.3-5.7-5-11.5-9.2-11.5-16C3 11.3 7.7 6.1 13.4 6.1c4.2 0 6.5 2 8.1 4.3 1.9 2.6 2.2 3.9 2.5 3.9.3 0 .6-1.3 2.5-3.9 1.6-2.3 3.9-4.3 8.1-4.3m0-3c-4.5 0-7.9 1.8-10.6 5.6-2.7-3.7-6.1-5.5-10.6-5.5C6 3.1 0 9.6 0 17.6c0 7.3 5.4 12 10.6 16.5.6.5 1.3 1.1 1.9 1.7l2.3 2c4.4 3.9 6.6 5.9 7.6 6.5.5.3 1.1.5 1.6.5.6 0 1.1-.2 1.6-.5 1-.6 2.8-2.2 7.8-6.8l2-1.8c.7-.6 1.3-1.2 2-1.7C42.7 29.6 48 25 48 17.6c0-8-6-14.5-13.4-14.5z"></path>
-              </svg>
-            </p>
-          </div>
-          <PostDate
-            posting_time={datum?.posted_on}
-            isExtended={isExtended}
-          />
+function CommentSection({ index, comments, isExpanded, setIsExpanded }) {
+  const commentsSummary = comments.slice(0, isExpanded ? undefined : 2);
+  return (
+    <section
+      className={classnames('comments-section', {
+        'is-expanded': isExpanded,
+      })}
+    >
+      {!isExpanded && (
+        <div>
+          <Link
+            to={`/p/${index}`}
+            className="view-comments-button"
+            onClick={() => {
+              setIsExpanded(true);
+            }}
+          >
+            View all comments
+          </Link>
         </div>
-      </div>
-      <PostInput index={index} />
-    </>
-  );
-
-  const expandedContent = (
-    <>
-      <div className="post-container-floating">
-        <img
-          className="post-img-extended"
-          src={datum?.post_image}
-          alt={datum?.post_caption}
-          loading="lazy"
-        />
-        <div className="content-section">
-          <PostHeader
-            city={datum?.city}
-            user_name={datum?.user_name}
-            isExtended
-            user_thumbnail={datum?.user_thumbnail}
-          />
-          <div className="comment-section-extended">
-            <div className="post-caption-avatar-text-extended">
-              <img
-                className="caption-user-avatar-extended"
-                src={datum?.user_thumbnail}
-                alt="User Avatar"
-              />
-              <p className="post-caption-extended">
-                <span className="post-caption-username-extended">
-                  {datum?.user_name}
-                </span>
-                {datum?.post_caption}
+      )}
+      {commentsSummary.map((comment) => (
+        <div
+          className={classnames('comment-wrapper', {
+            'is-expanded': isExpanded,
+          })}
+        >
+          {isExpanded && <Avatar src={comment.user_thumbnail} size="32" />}
+          <div className="comment-body">
+            <div>
+              <p className="comment-text">
+                <strong>{comment.user_name}</strong> {comment.comment}
               </p>
             </div>
-            {datum?.comments.map((comment) => (
-              <div className="comment-extended">
-                <img
-                  className="comment-user-avatar-extended"
-                  src={comment.user_thumbnail}
-                  alt="User Avatar"
-                />
-                <div className="comment-username-comment-extended">
-                  <div className="comment-user-info-extended">
-                    <p>
-                      <strong>{comment.user_name}</strong> {comment.comment}
-                    </p>
-                  </div>
-                  <div className="post-like-replay-section-extended">
-                    <button className="comment-time-extended">2 w</button>
-                    <button className="like-button">
-                      {comment.comment_likes}
-                      <strong>
-                        {comment.comment_likes > 0 ? ' Likes' : ' like'}
-                      </strong>
-                    </button>
-                    <button className="reply-button">
-                      <strong>Reply</strong>
-                    </button>
-                  </div>
-                </div>
-                <svg
-                  aria-label="Like"
-                  className="_8-yf5 "
-                  color={comment.is_liked_by_user ? '#ed4956' : '#8e8e8e'}
-                  fill={comment.is_liked_by_user ? '#ed4956' : '#8e8e8e'}
-                  height="12"
-                  role="img"
-                  viewBox="0 0 48 48"
-                  width="12"
-                >
-                  <path d="M34.6 6.1c5.7 0 10.4 5.2 10.4 11.5 0 6.8-5.9 11-11.5 16S25 41.3 24 41.9c-1.1-.7-4.7-4-9.5-8.3-5.7-5-11.5-9.2-11.5-16C3 11.3 7.7 6.1 13.4 6.1c4.2 0 6.5 2 8.1 4.3 1.9 2.6 2.2 3.9 2.5 3.9.3 0 .6-1.3 2.5-3.9 1.6-2.3 3.9-4.3 8.1-4.3m0-3c-4.5 0-7.9 1.8-10.6 5.6-2.7-3.7-6.1-5.5-10.6-5.5C6 3.1 0 9.6 0 17.6c0 7.3 5.4 12 10.6 16.5.6.5 1.3 1.1 1.9 1.7l2.3 2c4.4 3.9 6.6 5.9 7.6 6.5.5.3 1.1.5 1.6.5.6 0 1.1-.2 1.6-.5 1-.6 2.8-2.2 7.8-6.8l2-1.8c.7-.6 1.3-1.2 2-1.7C42.7 29.6 48 25 48 17.6c0-8-6-14.5-13.4-14.5z"></path>
-                </svg>
+            {isExpanded && (
+              <div>
+                <time className="comment-action">2w</time>
+                <button className="comment-action">
+                  <strong>
+                    {comment.comment_likes}
+                    {comment.comment_likes > 0 ? ' likes' : ' like'}
+                  </strong>
+                </button>
+                <button className="comment-action">
+                  <strong>Reply</strong>
+                </button>
               </div>
-            ))}
+            )}
           </div>
-          <PostActions is_post_liked={datum?.is_post_liked} />
-          <p className="likes-count">
-            Liked by <strong>{datum?.user_name}</strong> and
-            <strong>{datum?.likes_count} others </strong>
-          </p>
-          <PostDate
-            posting_time={datum?.posting_time}
-            isExtended={isExtended}
-          />
-          <PostInput index={index} />
+          <svg
+            aria-label="Like"
+            className="like-comment-icon"
+            color={comment.is_liked_by_user ? '#ed4956' : '#8e8e8e'}
+            fill={comment.is_liked_by_user ? '#ed4956' : '#8e8e8e'}
+            height="12"
+            role="img"
+            viewBox="0 0 48 48"
+            width="12"
+          >
+            <path d="M34.6 6.1c5.7 0 10.4 5.2 10.4 11.5 0 6.8-5.9 11-11.5 16S25 41.3 24 41.9c-1.1-.7-4.7-4-9.5-8.3-5.7-5-11.5-9.2-11.5-16C3 11.3 7.7 6.1 13.4 6.1c4.2 0 6.5 2 8.1 4.3 1.9 2.6 2.2 3.9 2.5 3.9.3 0 .6-1.3 2.5-3.9 1.6-2.3 3.9-4.3 8.1-4.3m0-3c-4.5 0-7.9 1.8-10.6 5.6-2.7-3.7-6.1-5.5-10.6-5.5C6 3.1 0 9.6 0 17.6c0 7.3 5.4 12 10.6 16.5.6.5 1.3 1.1 1.9 1.7l2.3 2c4.4 3.9 6.6 5.9 7.6 6.5.5.3 1.1.5 1.6.5.6 0 1.1-.2 1.6-.5 1-.6 2.8-2.2 7.8-6.8l2-1.8c.7-.6 1.3-1.2 2-1.7C42.7 29.6 48 25 48 17.6c0-8-6-14.5-13.4-14.5z"></path>
+          </svg>
         </div>
-      </div>
-    </>
+      ))}
+    </section>
   );
+}
+export function Post({ datum, isExpanded, setIsExpanded, index, isFloating }) {
   const history = useHistory();
   return (
-    <div
+    <article
       onClick={(event) => {
         event.target === event.currentTarget && history.push('/');
       }}
       className={classnames('post-overlay', {
-        'is-extended': isExtended,
+        'is-expanded': isExpanded,
         'is-floating': isFloating,
       })}
     >
-      <div className={isExtended ? 'content-extended' : 'content'}>
-        {isExtended ? (
-          expandedContent
-        ) : (
-          <div className="post-container">{[content]}</div>
-        )}
+      <div
+        className={classnames('post-content', { 'is-expanded': isExpanded })}
+      >
+        <>
+          <PostHeader
+            city={'Baghdad'}
+            user_name={datum?.user_name}
+            user_thumbnail={datum?.user_thumbnail}
+          />
+
+          <section className="img-container">
+            <img
+              className="post-img"
+              src={datum?.post_image}
+              alt=""
+              loading="lazy"
+            />
+          </section>
+
+          <PostActions index={index} is_post_liked={datum?.is_post_liked} />
+
+          <section className="like-count">
+            Liked by <strong>{datum?.user_name}</strong> and
+            <strong> {datum?.likes_count} others </strong>
+          </section>
+          <section className="post-caption-section">
+            {isExpanded && <Avatar src={datum?.user_thumbnail} />}
+            <p className="post-caption-text">
+              <strong>{datum?.user_name}</strong> {datum?.post_caption}
+            </p>
+          </section>
+          <CommentSection
+            index={index}
+            setIsExpanded={setIsExpanded}
+            comments={datum.comments}
+            isExpanded={isExpanded}
+          />
+          <PostDate
+            posting_time={datum?.posting_time}
+            isExpanded={isExpanded}
+          />
+          <PostInput index={index} />
+        </>
       </div>
-    </div>
+    </article>
   );
 }

--- a/src/PostPage.js
+++ b/src/PostPage.js
@@ -11,7 +11,7 @@ export function PostPage({ postId, isFloating }) {
         index={postId}
         datum={post}
         comments={post?.comments}
-        isExtended={true}
+        isExpanded={true}
         isFloating={isFloating}
       />
     </div>

--- a/src/UserStories/UserStories.js
+++ b/src/UserStories/UserStories.js
@@ -132,7 +132,7 @@ export function UserStories({ userId }) {
                   }
                 }}
                 className={cx('stories-container', {
-                  'is-extended': activeStory,
+                  'is-expanded': activeStory,
                   'is-small': !activeStory,
                 })}
                 style={{ transition: 'all 0.5s ease-out' }}
@@ -146,7 +146,7 @@ export function UserStories({ userId }) {
               >
                 <div
                   className={cx('story-header', {
-                    'is-extended': activeStory,
+                    'is-expanded': activeStory,
                     'is-small': !activeStory,
                   })}
                 >
@@ -182,7 +182,7 @@ export function UserStories({ userId }) {
 
                   <p
                     className={cx('story-username', {
-                      'is-extended': activeStory,
+                      'is-expanded': activeStory,
                       'is-small': !activeStory,
                     })}
                   >
@@ -190,7 +190,7 @@ export function UserStories({ userId }) {
                   </p>
                   <p
                     className={cx('story-post-time', {
-                      'is-extended': activeStory,
+                      'is-expanded': activeStory,
                       'is-small': !activeStory,
                     })}
                   >
@@ -216,7 +216,7 @@ export function UserStories({ userId }) {
 
                 <div
                   className={cx('story-body', {
-                    'is-extended': activeStory,
+                    'is-expanded': activeStory,
                     'is-small': !activeStory,
                   })}
                 >


### PR DESCRIPTION
### Changes 

This PR moves `Post` component to CSS grid for:
1. DRYer code between expanded and normal post states.
2. Easier responsivity in the future.
3. To exercise building complicated CSS grids.

### Testing steps
1. Run `npm start`.
2. Post should look good in the Home page (compare to instagram.com).
3. "View all comments" should work properly (opens the post overlay).
4. The post overlay should look good (compare to IG).
5. Refresh the page while at the overlay, the post should still be visible but alone.

Fixes #8