### PR TITLE
Implement dragging support on mobile for posts with multiple items

### DIFF
--- a/components/Avatar/Avatar.js
+++ b/components/Avatar/Avatar.js
@@ -39,7 +39,6 @@ export function Avatar({
       dimensions.strokeWidth = 5;
       break;
     default:
-      dimensions.imgDiameter = size;
       dimensions.SVGDiameter = size;
       break;
   }
@@ -75,18 +74,14 @@ export function Avatar({
               />
             </g>
           )}
-          <foreignObject x="0" y="0" width="300" height="300">
-            {user?.user_thumbnail && (
-              <div style={{ margin: 20 }}>
-                <Image
-                  src={user.user_thumbnail}
-                  alt={`${user.user_name} avatar`}
-                  className={styles.userAvatar}
-                  width="260"
-                  height="260"
-                />
-              </div>
-            )}
+          <foreignObject x="20" y="20" width="300" height="300">
+            <img
+              src={user?.user_thumbnail}
+              alt={`${user?.user_name} avatar`}
+              className={styles.userAvatar}
+              width="260"
+              height="260"
+            />
           </foreignObject>
         </svg>
       </a>

--- a/components/Avatar/Avatar.module.css
+++ b/components/Avatar/Avatar.module.css
@@ -24,5 +24,4 @@
 .userAvatar {
   border-radius: 50%;
   display: block;
-  margin: 20px;
 }

--- a/components/Post/Post.js
+++ b/components/Post/Post.js
@@ -8,6 +8,8 @@ import { Avatar } from '../Avatar/Avatar';
 import { CircularChevron } from '../Icons/CircularChevron';
 import { PostImage } from '../PostImage/PostImage';
 import { PostVideo } from '../PostVideo/PostVideo';
+import { useMediaQuery } from '../../utils/index';
+
 import {
   absoluteToRelativeDate,
   digitGrouping,
@@ -432,23 +434,39 @@ function MediaSection({ post, isExpanded, dimensions }) {
   const { postLike } = useDispatch('ig-posts');
   const mediaSection = React.useRef();
 
+  const isMobile = useMediaQuery('(max-width: 720px)');
+
   React.useEffect(() => {
-    mediaSection.current.scrollLeft =
-      mediaIndex * (isExpanded ? dimensions.width : 614);
-  }, [mediaIndex, isExpanded, dimensions]);
+    // this effect is meant to scroll the mediaSection when the nav buttons are clicked/
+    // since we don't show them on mobiles, we can disable it.
+    if (!isMobile) {
+      mediaSection.current.scrollLeft =
+        mediaIndex * (isExpanded ? dimensions.width : 614);
+    }
+  }, [mediaIndex, isExpanded, dimensions, isMobile]);
 
   return (
     <>
       <section
         ref={mediaSection}
         className={cx(styles.mediaSection, { [styles.isExpanded]: isExpanded })}
-        style={{ maxWidth: isExpanded ? dimensions.width : 614 }}
+        style={{
+          // only enable scrolling on mobiles
+          overflowX: isMobile ? 'auto' : 'hidden',
+          maxWidth: isExpanded ? dimensions.width : 614,
+        }}
         onScroll={(e) => {
-          const page = e.currentTarget.scrollLeft / e.currentTarget.clientWidth;
+          // only support scrolling navigation on mobile to support dragging
+          if (isMobile) {
+            const page =
+              e.currentTarget.scrollLeft / e.currentTarget.clientWidth;
 
-          // when page is an integer, it means the scroll event is done. Because page goes from 0 -> 0.1 -> 0.2 ... 1, then 1.1, 1.2 ... 2
-          if (Number.isInteger(page)) {
-            setMediaIndex(page);
+            // when page is an integer, it means the scroll event is done. Because page goes from 0 -> 0.1 -> 0.2 ... 1, then 1.1, 1.2 ... 2
+            if (Number.isInteger(page)) {
+              setMediaIndex(page);
+            }
+          } else {
+            e.preventDefault();
           }
         }}
       >
@@ -495,7 +513,7 @@ function MediaSection({ post, isExpanded, dimensions }) {
             />
           )
         )}
-        {items.length > 1 && !isLoading && (
+        {!isMobile && items.length > 1 && !isLoading && (
           <div className={styles.imgButtonsContainer}>
             <button
               className={cx(styles.prevImgButton, {

--- a/components/Post/Post.js
+++ b/components/Post/Post.js
@@ -473,10 +473,7 @@ function MediaSection({ post, isExpanded, dimensions }) {
             const page =
               e.currentTarget.scrollLeft / e.currentTarget.clientWidth;
 
-            // when page is an integer, it means the scroll event is done. Because page goes from 0 -> 0.1 -> 0.2 ... 1, then 1.1, 1.2 ... 2
-            if (Number.isInteger(page)) {
-              setMediaIndex(page);
-            }
+            setMediaIndex(Math.round(page));
           }
         }}
       >

--- a/components/Post/Post.js
+++ b/components/Post/Post.js
@@ -430,68 +430,71 @@ function MediaSection({ post, isExpanded, dimensions }) {
   const [mediaIndex, setMediaIndex] = React.useState(0);
   const [isLoading, setIsLoading] = React.useState(true);
   const { postLike } = useDispatch('ig-posts');
+  const mediaSection = React.useRef();
+
+  React.useEffect(() => {
+    mediaSection.current.scrollLeft =
+      mediaIndex * (isExpanded ? dimensions.width : 614);
+  }, [mediaIndex, isExpanded, dimensions]);
 
   return (
     <>
       <section
+        ref={mediaSection}
         className={cx(styles.mediaSection, { [styles.isExpanded]: isExpanded })}
         style={{ maxWidth: isExpanded ? dimensions.width : 614 }}
+        onScroll={(e) => {
+          const page = e.currentTarget.scrollLeft / e.currentTarget.clientWidth;
+
+          // when page is an integer, it means the scroll event is done. Because page goes from 0 -> 0.1 -> 0.2 ... 1, then 1.1, 1.2 ... 2
+          if (Number.isInteger(page)) {
+            setMediaIndex(page);
+          }
+        }}
       >
-        <div
-          className={styles.mediaContainer}
-          style={{
-            transform: `translateX(${(-mediaIndex * 100) / items.length}%)`,
-            width: `${100 * items.length}%`,
-          }}
-        >
-          {items?.map((mediaItem, index) =>
-            mediaItem.type === 'photo' ? (
-              index === 0 ? (
-                <PostImage
-                  key={index}
-                  imageURL={mediaItem.url}
-                  fraction={1 / items.length}
-                  aspectRatio={aspectRatio}
-                  setIsLoading={setIsLoading}
-                  isLoading={isLoading}
-                  onDoubleClick={() => postLike(post.post_id)}
-                  tags={mediaItem.tags}
-                  postDimensions={post.media_dimensions}
-                  isActive={mediaIndex === index}
-                />
-              ) : (
-                <PostImage
-                  key={index}
-                  imageURL={mediaItem.url}
-                  fraction={1 / items.length}
-                  aspectRatio={aspectRatio}
-                  onDoubleClick={() => postLike(post.post_id)}
-                  tags={mediaItem.tags}
-                  postDimensions={post.media_dimensions}
-                  isActive={mediaIndex === index}
-                />
-              )
-            ) : index === 0 ? (
-              <PostVideo
+        {items?.map((mediaItem, index) =>
+          mediaItem.type === 'photo' ? (
+            index === 0 ? (
+              <PostImage
                 key={index}
-                videoURL={mediaItem.url}
-                active={mediaIndex === index}
-                fraction={1 / items.length}
+                imageURL={mediaItem.url}
                 aspectRatio={aspectRatio}
                 setIsLoading={setIsLoading}
                 isLoading={isLoading}
+                onDoubleClick={() => postLike(post.post_id)}
+                tags={mediaItem.tags}
+                postDimensions={post.media_dimensions}
+                isActive={mediaIndex === index}
               />
             ) : (
-              <PostVideo
+              <PostImage
                 key={index}
-                videoURL={mediaItem.url}
-                active={mediaIndex === index}
-                fraction={1 / items.length}
+                imageURL={mediaItem.url}
                 aspectRatio={aspectRatio}
+                onDoubleClick={() => postLike(post.post_id)}
+                tags={mediaItem.tags}
+                postDimensions={post.media_dimensions}
+                isActive={mediaIndex === index}
               />
             )
-          )}
-        </div>
+          ) : index === 0 ? (
+            <PostVideo
+              key={index}
+              videoURL={mediaItem.url}
+              active={mediaIndex === index}
+              aspectRatio={aspectRatio}
+              setIsLoading={setIsLoading}
+              isLoading={isLoading}
+            />
+          ) : (
+            <PostVideo
+              key={index}
+              videoURL={mediaItem.url}
+              active={mediaIndex === index}
+              aspectRatio={aspectRatio}
+            />
+          )
+        )}
         {items.length > 1 && !isLoading && (
           <div className={styles.imgButtonsContainer}>
             <button

--- a/components/Post/Post.js
+++ b/components/Post/Post.js
@@ -444,11 +444,8 @@ function MediaSection({ post, isExpanded, dimensions }) {
   React.useEffect(() => {
     // this effect is meant to scroll the mediaSection when the nav buttons are clicked/
     // since we don't show them on mobiles, we can disable it.
-    if (isMobile) {
-      mediaSection.current.scrollLeft =
-        mediaIndex * (isExpanded ? dimensions.width : 612);
-    } else {
-      // dont use scrolling on Desktop, because it's problematic on Safari
+    // dont use scrolling on Desktop, because it's problematic on Safari
+    if (!isMobile) {
       firstImage.current.style.marginLeft = `${
         -mediaIndex * (isExpanded ? dimensions.width : 612)
       }px`;

--- a/components/Post/Post.js
+++ b/components/Post/Post.js
@@ -437,28 +437,23 @@ function MediaSection({ post, isExpanded, dimensions }) {
   const [isLoading, setIsLoading] = React.useState(true);
   const { postLike } = useDispatch('ig-posts');
   const mediaSection = React.useRef();
+  const firstImage = React.useRef();
 
   const isMobile = useMediaQuery('(max-width: 720px)');
 
   React.useEffect(() => {
     // this effect is meant to scroll the mediaSection when the nav buttons are clicked/
     // since we don't show them on mobiles, we can disable it.
-    if (!isMobile) {
-      mediaSection.current.scrollTo({
-        left: mediaIndex * (isExpanded ? dimensions.width : 614),
-        behavior: 'smooth',
-        top:0
-      });
+    if (isMobile) {
+      mediaSection.current.scrollLeft =
+        mediaIndex * (isExpanded ? dimensions.width : 612);
+    } else {
+      // dont use scrolling on Desktop, because it's problematic on Safari
+      firstImage.current.style.marginLeft = `${
+        -mediaIndex * (isExpanded ? dimensions.width : 612)
+      }px`;
     }
   }, [mediaIndex, isExpanded, dimensions, isMobile]);
-  React.useEffect(() => {
-    // this effect is meant to scroll the mediaSection when the nav buttons are clicked/
-    // since we don't show them on mobiles, we can disable it.
-    if (!isMobile) {
-      mediaSection.current.scrollLeft =
-        mediaIndex * (isExpanded ? dimensions.width : 614);
-    }
-  }, [mediaIndex, isMobile, isExpanded, dimensions]);
 
   return (
     <>
@@ -468,7 +463,8 @@ function MediaSection({ post, isExpanded, dimensions }) {
         style={{
           // only enable scrolling on mobiles
           overflowX: isMobile ? 'auto' : 'hidden',
-          maxWidth: isExpanded ? dimensions.width : 614,
+          maxWidth: isExpanded ? dimensions.width : 612,
+          '--scrollLeft': '500px',
         }}
         onScroll={(e) => {
           // only support scrolling navigation on mobile to support dragging
@@ -493,6 +489,7 @@ function MediaSection({ post, isExpanded, dimensions }) {
                 tags={mediaItem.tags}
                 postDimensions={post.media_dimensions}
                 isActive={mediaIndex === index}
+                wrapperRef={firstImage}
               />
             ) : (
               <PostImage

--- a/components/Post/Post.js
+++ b/components/Post/Post.js
@@ -444,8 +444,11 @@ function MediaSection({ post, isExpanded, dimensions }) {
     // this effect is meant to scroll the mediaSection when the nav buttons are clicked/
     // since we don't show them on mobiles, we can disable it.
     if (!isMobile) {
-      mediaSection.current.scrollLeft =
-        mediaIndex * (isExpanded ? dimensions.width : 614);
+      mediaSection.current.scrollTo({
+        left: mediaIndex * (isExpanded ? dimensions.width : 614),
+        behavior: 'smooth',
+        top:0
+      });
     }
   }, [mediaIndex, isExpanded, dimensions, isMobile]);
   React.useEffect(() => {

--- a/components/Post/Post.js
+++ b/components/Post/Post.js
@@ -449,9 +449,13 @@ function MediaSection({ post, isExpanded, dimensions }) {
     }
   }, [mediaIndex, isExpanded, dimensions, isMobile]);
   React.useEffect(() => {
-    mediaSection.current.scrollLeft =
-      mediaIndex * (isExpanded ? dimensions.width : 614);
-  }, [mediaIndex, isExpanded, dimensions]);
+    // this effect is meant to scroll the mediaSection when the nav buttons are clicked/
+    // since we don't show them on mobiles, we can disable it.
+    if (!isMobile) {
+      mediaSection.current.scrollLeft =
+        mediaIndex * (isExpanded ? dimensions.width : 614);
+    }
+  }, [mediaIndex, isMobile, isExpanded, dimensions]);
 
   return (
     <>
@@ -473,8 +477,6 @@ function MediaSection({ post, isExpanded, dimensions }) {
             if (Number.isInteger(page)) {
               setMediaIndex(page);
             }
-          } else {
-            e.preventDefault();
           }
         }}
       >

--- a/components/Post/Post.js
+++ b/components/Post/Post.js
@@ -24,7 +24,7 @@ function calculatePostDimensions(post, isInFeed) {
     post.media_dimensions.width / post.media_dimensions.height;
   if (isInFeed) {
     const VERTICAL_MARGIN = 24;
-    const height = window.innerHeight - VERTICAL_MARGIN * 2;
+    const height = Math.min(post.media_dimensions.height, window.innerHeight - VERTICAL_MARGIN * 2);
     const width = height * postAspectRatio;
     return { width, height };
   } else {

--- a/components/Post/Post.module.css
+++ b/components/Post/Post.module.css
@@ -155,17 +155,31 @@ section.postHeader {
 }
 
 section.mediaSection {
+  /* we need position: relative to make the navigation buttons absolute in relation to parent */
+  position: relative;
   grid-area: media;
-  overflow: hidden;
-}
-.mediaContainer {
+  overflow: auto;
+  scroll-snap-type: x mandatory;
   display: flex;
-  width: max-content;
-  transition: transform 0.25s ease-in-out;
+  flex: none;
+  flex-flow: row nowrap;
   height: 100%;
   align-items: center;
   background-color: #262626;
+  width: 100%;
+  scroll-behavior: smooth;
 }
+
+section.mediaSection::-webkit-scrollbar {
+  display: none;
+}
+
+section.mediaSection > * {
+  width: 100%;
+  scroll-snap-align: center;
+  flex: none;
+}
+
 section.progressDotsSection {
   grid-area: progress;
 }
@@ -463,13 +477,14 @@ section.commentInputSection {
   cursor: pointer;
 }
 .imgButtonsContainer {
-  position: relative;
-  top: -50%;
+  position: sticky;
+  right: 0%;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  height: 0;
-  background: rgba(0, 0, 0, 0.1);
+  background: none;
+  padding: 0 5px;
+  box-sizing: border-box;
 }
 .nextImgButton,
 .prevImgButton {
@@ -480,8 +495,15 @@ section.commentInputSection {
   width: 23px;
   border: none;
   background: transparent;
-  box-shadow: 2px 2px 6px 1px rgba(0, 0, 0, 0.28);
+  box-shadow: 2px 2px 6px 1px rgba(0, 0, 0, 0.2);
+  cursor: pointer;
+  opacity: 0.8;
 }
+.nextImgButton:hover,
+.prevImgButton:hover {
+  opacity: 1;
+}
+
 .nextImgButton.hidden,
 .prevImgButton.hidden {
   visibility: hidden;

--- a/components/Post/Post.module.css
+++ b/components/Post/Post.module.css
@@ -43,7 +43,7 @@
     'media time'
     'media input'
     'progress input';
-  
+
   max-width: calc(100vw - 100px);
   min-height: 467px;
   /* for border radius */
@@ -168,6 +168,10 @@ section.mediaSection {
   background-color: #262626;
   width: 100%;
   scroll-behavior: smooth;
+}
+
+section.mediaSection > :first-child {
+  transition: margin-left 0.5s ease-in-out;
 }
 
 section.mediaSection::-webkit-scrollbar {

--- a/components/PostImage/PostImage.js
+++ b/components/PostImage/PostImage.js
@@ -28,7 +28,6 @@ const useElementOnScreen = (options) => {
 
 export function PostImage({
   imageURL,
-  fraction,
   aspectRatio,
   isLoading,
   setIsLoading,
@@ -57,11 +56,10 @@ export function PostImage({
         setIsImgDoubleCLicked(true);
         setTimeout(setIsImgDoubleCLicked, 1500, false);
       }}
-      width={`${fraction * 100}%`}
       className={cx(styles.imgContainer, {
         [styles.isLoading]: isLoading,
       })}
-      style={{ aspectRatio, width: `${fraction * 100}%` }}
+      style={{ aspectRatio }}
     >
       <Image
         className={cx(styles.postImg, {

--- a/components/PostImage/PostImage.js
+++ b/components/PostImage/PostImage.js
@@ -35,6 +35,8 @@ export function PostImage({
   tags,
   postDimensions,
   isActive,
+  style,
+  wrapperRef
 }) {
   const [isImgDoubleClicked, setIsImgDoubleCLicked] = React.useState(false);
   const [isImgClicked, setIsImgCLicked] = React.useState(false);
@@ -59,7 +61,8 @@ export function PostImage({
       className={cx(styles.imgContainer, {
         [styles.isLoading]: isLoading,
       })}
-      style={{ aspectRatio }}
+      style={{ aspectRatio, ...style }}
+      ref={wrapperRef}
     >
       <Image
         className={cx(styles.postImg, {

--- a/components/PostVideo/PostVideo.js
+++ b/components/PostVideo/PostVideo.js
@@ -6,7 +6,6 @@ import cx from 'classnames';
 export function PostVideo({
   videoURL,
   active,
-  fraction,
   aspectRatio,
   isLoading,
   setIsLoading,
@@ -33,11 +32,10 @@ export function PostVideo({
   return (
     <div
       onClick={() => setVideoPause(!videoPause)}
-      width={`${fraction * 100}%`}
       className={cx(styles.videoContainer, {
         [styles.isLoading]: isLoading,
       })}
-      style={{ aspectRatio, width: `${fraction * 100}%` }}
+      style={{ aspectRatio }}
     >
       <video
         className={styles.postVideo}

--- a/components/pages/WarningPage/WarningPage.js
+++ b/components/pages/WarningPage/WarningPage.js
@@ -240,8 +240,7 @@ export function WarningPage({ setShouldWarn }) {
           <g id="Eyes">
             <circle
               ref={leftEyeRef}
-              transform-origin="168 106"
-              transform={`rotate(${leftEyeAngle})`}
+              transform={`rotate(${leftEyeAngle}, 168, 106)`}
               fill="#FFFFFF"
               cx="172"
               cy="106"
@@ -250,8 +249,7 @@ export function WarningPage({ setShouldWarn }) {
 
             <circle
               ref={rightEyeRef}
-              transform-origin="232 94"
-              transform={`rotate(${rightEyeAngle})`}
+              transform={`rotate(${rightEyeAngle}, 232, 94)`}
               fill="#FFFFFF"
               cx="237"
               cy="94"


### PR DESCRIPTION
I learned today about [`scroll-snap-type`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-snap-type). It's a new feature that lets your scrolling snap to the children of a given container. This is as opposed from free flowing scroll, which is the norm.

This means we don't need to do our own calculation for switching between items in a post. And we could just snap the scroll to each item, then just scroll between them. 

This allows switching between items on mobiles by simply dragging the item left or right.